### PR TITLE
docutils 0.18.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.17.1" %}
+{% set version = "0.18.1" %}
 
 package:
   name: docutils
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/docutils/docutils-{{ version }}.tar.gz
-  sha256: 686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125
+  sha256: 679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,13 +9,16 @@ source:
   sha256: 679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
 
 build:
-  number: 1
+  number: 0
+  # cannot be noarch b/c of scripts
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 
@@ -39,12 +42,16 @@ test:
     - docutils.writers.pep_html
     - docutils.writers.s5_html
     - docutils.writers.xetex
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://docutils.sourceforge.net/
-  license: Public Domain Dedictation and BSD 2-Clause and PSF 2.1.1 and GPL 3.0
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
   license_file: COPYING.txt
-  summary: 'Docutils -- Python Documentation Utilities'
+  summary: Docutils -- Python Documentation Utilities
   description: |
     Docutils is an open-source text processing system for processing plaintext
     documentation into useful formats, such as HTML, LaTeX, man-pages, open-


### PR DESCRIPTION
Update docutils to 0.18.1

Version change: bump version number from 0.17.1 to 0.18.1
Changes: http://svn.code.sf.net/p/docutils/code/tags/docutils-0.18.1/HISTORY.txt
Upstream setup file: https://svn.code.sf.net/p/docutils/code/tags/docutils-0.18.1/setup.py
Requirements: https://svn.code.sf.net/p/docutils/code/tags/docutils-0.18.1/README.txt

The package docutils is mentioned inside the packages:
airflow | altair | altair3_2 | altiar | botocore-1.10.12 | botocore-1.8.21 | email-validator | flit | orange3 | orange-canvas-core | python-daemon | python-daemon-2.2.3 | readme_renderer | recommonmark | sphinx | statistics |

Actions:
1. Reset build number to 0
2. Add pip check

Result:
- all-succeeded