### PR TITLE
docutils 0.19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "docutils" %}
-{% set version = "0.18.1" %}
+{% set version = "0.19" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/docutils-{{ version }}.tar.gz
-  sha256: 679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
+  sha256: 33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6
 
 build:
   number: 3


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 9ef27e1..d6912c9 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "docutils" %}
-{% set version = "0.18.1" %}
+{% set version = "0.19" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/docutils-{{ version }}.tar.gz
-  sha256: 679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06
+  sha256: 33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6
 
 build:
   number: 3

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.19
 * Release on PyPi:
    * version: 0.19
    * date: 2022-07-05T20:17:31
* [PyPi history](https://pypi.org/project/docutils/#history)
 * Popularity: 
    * 3 months downloads: 1205512.0
    * All time:  14083497 downloads -  docutils  0.19  Docutils -- Python Documentation Utilities  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: COPYING.txt is present

14. - [x] license_family Other is present
16. - [x] License: LicenseRef-Public-Domain-Dedictation
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|--------------|
</details>

**Check dependency issues:**

<details>
../aggregate/docutils-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'wheel', 'setuptools', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/docutils-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/docutils-feedstock/tree/0.19)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/docutils)
* [Diff between upstream and feature branch](https://github.com/conda-forge/docutils-feedstock/compare/main...AnacondaRecipes:0.19)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/docutils-feedstock/compare/master...AnacondaRecipes:0.19)
* [The last merged PRs](https://github.com/AnacondaRecipes/docutils-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.19 git@github.com:AnacondaRecipes/docutils-feedstock.git
```
